### PR TITLE
[build] use setup-msbuild@v1.0.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,7 +80,7 @@ jobs:
           python-version: 3.7
       - name: Add msbuild to PATH
         if: matrix.os == 'windows-latest'
-        uses: microsoft/setup-msbuild@v1.0.0
+        uses: microsoft/setup-msbuild@v1.0.2
       - name: Build wheels
         env:
           CIBW_BEFORE_BUILD: scripts/build-libsrtp /tmp/vendor


### PR DESCRIPTION
Otherwise the build fails with the following error:

The `add-path` command is disabled.