### PR TITLE
Show where libsrtp could be installed on CentOS & derivatives

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,12 @@ On Debian/Ubuntu run:
 
     $ apt install libsrtp2-dev
 
+On Fedora/CentOS run:
+
+.. code-block:: console
+
+    $ dnf install libsrtp-devel
+
 On OS X run:
 
 .. code-block:: console


### PR DESCRIPTION
`libsrtp-devel` on dnf, since Fedora / CentOS are also popular linux distributions.