### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,11 +76,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-14
             arch: arm64
-          - os: macos-latest
+          - os: macos-13
             arch: x86_64
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             arch: aarch64
           - os: ubuntu-latest
             arch: i686
@@ -94,15 +94,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Add msbuild to PATH
         if: matrix.os == 'windows-latest'
         uses: microsoft/setup-msbuild@v2
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
       - name: Build wheels
         env:
           CIBW_ARCHS: ${{ matrix.arch }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,8 @@ jobs:
         run: |
           brew update
           brew install srtp
+          echo "CFLAGS=-I$(brew --prefix openssl)/include -I$(brew --prefix srtp)/include" >> $GITHUB_ENV
+          echo "LDFLAGS=-L$(brew --prefix openssl)/lib -L$(brew --prefix srtp)/lib" >> $GITHUB_ENV
       - name: Install OS Packages
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,7 +107,7 @@ jobs:
           CIBW_BEFORE_BUILD_WINDOWS: scripts\build-libsrtp.bat C:\cibw\vendor
           CIBW_ENVIRONMENT: CFLAGS=-I/tmp/vendor/include LDFLAGS=-L/tmp/vendor/lib PKG_CONFIG_PATH=/tmp/vendor/lib/pkgconfig
           CIBW_ENVIRONMENT_WINDOWS: INCLUDE=C:\\cibw\\vendor\\include LIB=C:\\cibw\\vendor\\lib
-          CIBW_SKIP: '*-musllinux*'
+          CIBW_SKIP: '*-musllinux* pp**'
           CIBW_TEST_COMMAND: python -m unittest discover -s {project}/tests
         shell: bash
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
         run: pip install ruff
       - name: Run linters
         run: |
-          ruff .
+          ruff check .
           ruff format --check --diff .
 
   test:

--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,9 @@ Building pylibsrtp
 
 If you wish to build pylibsrtp yourself, you will need libsrtp version 2.0 or better.
 
+Linux
+.....
+
 On Debian/Ubuntu run:
 
 .. code-block:: console
@@ -92,11 +95,21 @@ On Fedora/CentOS run:
 
     $ dnf install libsrtp-devel
 
-On OS X run:
+macOS
+.....
+
+On macOS run:
 
 .. code-block:: console
 
     $ brew install srtp
+
+You will need to set some environment variables to link against libsrtp:
+
+.. code-block:: console
+
+   export CFLAGS=-I$(brew --prefix openssl)/include -I$(brew --prefix srtp)/include
+   export LDFLAGS=-L$(brew --prefix openssl)/lib -L$(brew --prefix srtp)/lib
 
 License
 -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ documentation = "https://pylibsrtp.readthedocs.io/"
 [tool.coverage.run]
 source = ["pylibsrtp"]
 
-[tool.ruff]
+[tool.ruff.lint]
 select = [
     "E",  # pycodestyle
     "F",  # Pyflakes

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,13 +5,10 @@ from unittest import TestCase
 from pylibsrtp import Error, Policy, Session
 
 RTP = (
-    (
-        b"\x80\x08\x00\x00"  # version, packet type, sequence number
-        b"\x00\x00\x00\x00"  # timestamp
-        b"\x00\x00\x30\x39"  # ssrc: 12345
-    )
-    + (b"\xd4" * 160)
-)
+    b"\x80\x08\x00\x00"  # version, packet type, sequence number
+    b"\x00\x00\x00\x00"  # timestamp
+    b"\x00\x00\x30\x39"  # ssrc: 12345
+) + (b"\xd4" * 160)
 RTCP = (
     b"\x80\xc8\x00\x06\xf3\xcb\x20\x01\x83\xab\x03\xa1\xeb\x02\x0b\x3a"
     b"\x00\x00\x94\x20\x00\x00\x00\x9e\x00\x00\x9b\x88"


### PR DESCRIPTION
- Pin the macOs versions for arm64 / x86_64.
- Build Linux aarch64 wheels natively.
- Use Python 3.11 as cibuildwheel will soon require it.