### PR TITLE
Fix readthedocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,3 +11,6 @@ python:
   install:
     - method: pip
       path: .
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
See:
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/