### PR TITLE
Build wheels for musllinux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,7 +107,7 @@ jobs:
           CIBW_BEFORE_BUILD_WINDOWS: scripts\build-libsrtp.bat C:\cibw\vendor
           CIBW_ENVIRONMENT: CFLAGS=-I/tmp/vendor/include LDFLAGS=-L/tmp/vendor/lib PKG_CONFIG_PATH=/tmp/vendor/lib/pkgconfig
           CIBW_ENVIRONMENT_WINDOWS: INCLUDE=C:\\cibw\\vendor\\include LIB=C:\\cibw\\vendor\\lib
-          CIBW_SKIP: '*-musllinux* pp**'
+          CIBW_SKIP: 'pp**'
           CIBW_TEST_COMMAND: python -m unittest discover -s {project}/tests
         shell: bash
         run: |

--- a/scripts/fetch-vendor.json
+++ b/scripts/fetch-vendor.json
@@ -1,3 +1,3 @@
 {
-    "urls": ["https://github.com/aiortc/aioquic-openssl/releases/download/3.4.0-1/openssl-{platform}.tar.gz"]
+    "urls": ["https://github.com/aiortc/aioquic-openssl/releases/download/3.4.1-1/openssl-{platform}.tar.gz"]
 }

--- a/scripts/fetch-vendor.py
+++ b/scripts/fetch-vendor.py
@@ -12,7 +12,10 @@ def get_platform():
     system = platform.system()
     machine = platform.machine()
     if system == "Linux":
-        return f"manylinux_{machine}"
+        if platform.libc_ver()[0] == "glibc":
+            return f"manylinux_{machine}"
+        else:
+            return f"musllinux_{machine}"
     elif system == "Darwin":
         # cibuildwheel sets ARCHFLAGS:
         # https://github.com/pypa/cibuildwheel/blob/5255155bc57eb6224354356df648dc42e31a0028/cibuildwheel/macos.py#L207-L220


### PR DESCRIPTION
Now that we have binary builds of OpenSSL for `musllinux`, we can produce binary wheels for this platform.